### PR TITLE
Гет параметры в apiCall

### DIFF
--- a/src/globals/api/apiCall.ts
+++ b/src/globals/api/apiCall.ts
@@ -51,7 +51,7 @@ export async function apiCall<TRequest extends APIRequest | false = false, TResp
 ): Promise<TResponse> {
   const { method = 'POST', request } = options
 
-  let url = new URL(uri, process.env.NEXT_PUBLIC_API_URL)
+  let url = new URL(`${process.env.NEXT_PUBLIC_API_URL}${uri}`).toString()
   const fetchInit: RequestInit = { method }
 
   if (request && method === 'POST') {
@@ -64,7 +64,7 @@ export async function apiCall<TRequest extends APIRequest | false = false, TResp
   if (request && method === 'GET') {
     // @ts-expect-error URLSearchParams преобразовывает объекты с boolean и числами в необходимый формат
     const searchParams = new URLSearchParams(request)
-    url = new URL(`${url.pathname}?${searchParams.toString()}`, process.env.NEXT_PUBLIC_API_URL)
+    url += `?${searchParams.toString()}`
   }
 
   const res = await fetch(url, fetchInit)

--- a/src/globals/api/methods/getCatalog.ts
+++ b/src/globals/api/methods/getCatalog.ts
@@ -4,7 +4,7 @@ import { apiCall, APIResponse } from '@/globals/api/apiCall'
 type Response = APIResponse<Category[]>
 
 export async function getCatalog(): Promise<Category[]> {
-  const res = await apiCall<false, Response>('catalog/all-categories', { method: 'GET' })
+  const res = await apiCall<false, Response>('/catalog/all-categories', { method: 'GET' })
 
   return res.data
 }

--- a/src/globals/api/methods/getSecondaryHousing.ts
+++ b/src/globals/api/methods/getSecondaryHousing.ts
@@ -15,6 +15,6 @@ interface SecondaryHousing {
 type Response = APIResponse<SecondaryHousing>
 
 export async function getSecondaryHousing() {
-  const res = await apiCall<false, Response>('catalog/secondary-housing', { method: 'GET' })
+  const res = await apiCall<false, Response>('/catalog/secondary-housing', { method: 'GET' })
   return res.data
 }

--- a/src/globals/api/methods/sendCallRequest.ts
+++ b/src/globals/api/methods/sendCallRequest.ts
@@ -7,6 +7,6 @@ type Request = APIRequest<{
 }>
 
 export async function sendCallRequest(request: Request): Promise<boolean> {
-  const res = await apiCall<Request, APIResponse<[]>>('feedback', { request })
+  const res = await apiCall<Request, APIResponse<[]>>('/feedback', { request })
   return res.message === 'Заявка отправлена'
 }


### PR DESCRIPTION
### Добавлено
- Поддержка get параметров для `GET` запроса в `apiCall()`

### Изменено
- Теперь нужно указывать первый `/` в начале пути для апи метода